### PR TITLE
Add basic Electron UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,4 @@ web/static/*.png
 
 # Local VSCode project settings
 .vscode/
+electron/node_modules/

--- a/README.md
+++ b/README.md
@@ -714,6 +714,16 @@ pnpm run dev
 
 ## or your equivalent
 ```
+### Electron UI
+
+A minimal Electron interface is available in the `electron/` directory. It lists all patterns and strategies and opens a page for each pattern using its required variables.
+
+```bash
+cd electron
+npm install
+npm start
+```
+
 
 ### Streamlit UI
 

--- a/electron/index.html
+++ b/electron/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Fabric Electron UI</title>
+  <style>
+    body { font-family: "Segoe UI", Tahoma, sans-serif; margin:0; display:flex; }
+    #sidebar { width:250px; background:#f3f3f3; overflow-y:auto; height:100vh; padding:1rem; }
+    #content { flex:1; padding:1rem; }
+    .tab { margin-right:1rem; cursor:pointer; display:inline-block; padding:0.5rem; }
+    .active { background:#ddd; }
+    input, textarea { width:100%; margin-bottom:0.5rem; }
+  </style>
+</head>
+<body>
+  <div id="sidebar">
+    <h3>Patterns</h3>
+    <ul id="patternList"></ul>
+    <h3>Strategies</h3>
+    <ul id="strategyList"></ul>
+  </div>
+  <div id="content">
+    <div id="tabs">
+      <span class="tab active" data-tab="run">Run</span>
+      <span class="tab" data-tab="settings">Settings</span>
+      <span class="tab" data-tab="history">History</span>
+    </div>
+    <div id="tabContent"></div>
+  </div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,45 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('run-pattern', async (evt, { name, vars }) => {
+  // Example invocation of the fabric CLI. This assumes `fabric` is in PATH.
+  // Replace with actual command as needed.
+  return new Promise((resolve) => {
+    const args = ['--pattern', name];
+    for (const [k, v] of Object.entries(vars)) {
+      args.push('-v', `${k}:${v}`);
+    }
+    const proc = spawn('fabric', args);
+    let output = '';
+    proc.stdout.on('data', (d) => {
+      output += d.toString();
+    });
+    proc.on('close', () => resolve(output));
+  });
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fabric-electron",
+  "version": "0.0.1",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "28.1.0"
+  }
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,44 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+function scanVariables(content) {
+  const regex = /\{\{([^{}]+)\}\}/g;
+  const vars = new Set();
+  let match;
+  while ((match = regex.exec(content))) {
+    const name = match[1].trim();
+    if (!name.startsWith('plugin:') && name !== 'input') {
+      vars.add(name);
+    }
+  }
+  return Array.from(vars);
+}
+
+function getPatterns() {
+  const pDir = path.join(__dirname, '..', 'patterns');
+  const names = fs.readdirSync(pDir).filter((p) => fs.statSync(path.join(pDir, p)).isDirectory());
+  return names.map((name) => {
+    const files = ['system.md', 'user.md'];
+    let content = '';
+    for (const f of files) {
+      const fp = path.join(pDir, name, f);
+      if (fs.existsSync(fp)) {
+        content += fs.readFileSync(fp, 'utf8');
+      }
+    }
+    const vars = scanVariables(content);
+    return { name, vars };
+  });
+}
+
+function getStrategies() {
+  const sDir = path.join(__dirname, '..', 'strategies');
+  return fs.readdirSync(sDir).filter((f) => f.endsWith('.json'));
+}
+
+contextBridge.exposeInMainWorld('fabricAPI', {
+  patterns: getPatterns(),
+  strategies: getStrategies(),
+  runPattern: (name, vars) => ipcRenderer.invoke('run-pattern', { name, vars })
+});

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -1,0 +1,61 @@
+const patternList = document.getElementById('patternList');
+const strategyList = document.getElementById('strategyList');
+const tabContent = document.getElementById('tabContent');
+const tabs = document.querySelectorAll('.tab');
+let history = [];
+
+function switchTab(tab) {
+  tabs.forEach(t => t.classList.remove('active'));
+  document.querySelector(`[data-tab="${tab}"]`).classList.add('active');
+  renderTab(tab);
+}
+
+function renderTab(tab) {
+  if (tab === 'run') {
+    tabContent.innerHTML = '<p>Select a pattern or strategy.</p>';
+  } else if (tab === 'settings') {
+    tabContent.innerHTML = '<h3>Settings</h3><p>Configure API keys and options here.</p>';
+  } else if (tab === 'history') {
+    tabContent.innerHTML = history.map(h => `<pre>${h}</pre>`).join('');
+  }
+}
+
+tabs.forEach(t => t.addEventListener('click', () => switchTab(t.dataset.tab)));
+renderTab('run');
+
+window.fabricAPI.patterns.forEach(p => {
+  const li = document.createElement('li');
+  li.textContent = p.name;
+  li.addEventListener('click', () => openPattern(p));
+  patternList.appendChild(li);
+});
+
+window.fabricAPI.strategies.forEach(s => {
+  const li = document.createElement('li');
+  li.textContent = s.replace('.json', '');
+  strategyList.appendChild(li);
+});
+
+function openPattern(p) {
+  switchTab('run');
+  let form = '';
+  p.vars.forEach(v => {
+    form += `<label>${v}<input id="var_${v}" /></label>`;
+  });
+  form += '<label>Input<textarea id="var_input"></textarea></label>';
+  form += `<button id="runBtn">Run ${p.name}</button><pre id="output"></pre>`;
+  tabContent.innerHTML = `<h3>${p.name}</h3>${form}`;
+  document.getElementById('runBtn').addEventListener('click', () => runPattern(p));
+}
+
+function runPattern(p) {
+  const vars = {};
+  p.vars.forEach(v => {
+    vars[v] = document.getElementById('var_' + v).value;
+  });
+  vars['input'] = document.getElementById('var_input').value;
+  window.fabricAPI.runPattern(p.name, vars).then(res => {
+    document.getElementById('output').textContent = res;
+    history.push(`PATTERN ${p.name}\n` + JSON.stringify(vars) + '\n' + res);
+  });
+}


### PR DESCRIPTION
## Summary
- add a minimal Electron based interface under `electron/`
- dynamically load patterns/strategies and build a page per pattern
- update `.gitignore` for electron deps
- document the new Electron UI in the README

## Testing
- `go test ./...` *(fails: unable to download toolchain)*
- `npm test` in `web` *(fails: vitest not found)*