### PR TITLE
Enhance Electron UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,4 @@ web/static/*.png
 
 # Local VSCode project settings
 .vscode/
+electron/node_modules/

--- a/README.md
+++ b/README.md
@@ -714,6 +714,16 @@ pnpm run dev
 
 ## or your equivalent
 ```
+### Electron UI
+
+A minimal Electron interface is available in the `electron/` directory. It lists all patterns and strategies and opens a page for each pattern using its required variables. The UI now includes search, descriptions, and a history tab.
+
+```bash
+cd electron
+npm install
+npm start
+```
+
 
 ### Streamlit UI
 

--- a/electron/index.html
+++ b/electron/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Fabric Electron UI</title>
+    <style>
+      body { font-family: "Segoe UI", Tahoma, sans-serif; margin:0; display:flex; }
+      #sidebar { width:250px; background:#f3f3f3; overflow-y:auto; height:100vh; padding:1rem; }
+      #content { flex:1; padding:1rem; }
+      #search { width:100%; margin-bottom:0.5rem; padding:0.25rem; }
+      .tab { margin-right:1rem; cursor:pointer; display:inline-block; padding:0.5rem; }
+      .active { background:#ddd; }
+      input, textarea { width:100%; margin-bottom:0.5rem; }
+    </style>
+</head>
+<body>
+  <div id="sidebar">
+    <input id="search" placeholder="Search..." />
+    <h3>Patterns</h3>
+    <ul id="patternList"></ul>
+    <h3>Strategies</h3>
+    <ul id="strategyList"></ul>
+  </div>
+  <div id="content">
+    <div id="tabs">
+      <span class="tab active" data-tab="run">Run</span>
+      <span class="tab" data-tab="settings">Settings</span>
+      <span class="tab" data-tab="history">History</span>
+    </div>
+    <div id="tabContent"></div>
+  </div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,57 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('run-pattern', async (evt, { name, vars }) => {
+  // Example invocation of the fabric CLI. This assumes `fabric` is in PATH.
+  // Replace with actual command as needed.
+  return new Promise((resolve) => {
+    const args = ['--pattern', name];
+    for (const [k, v] of Object.entries(vars)) {
+      args.push('-v', `${k}:${v}`);
+    }
+    const proc = spawn('fabric', args);
+    let output = '';
+    proc.stdout.on('data', (d) => {
+      output += d.toString();
+    });
+    proc.on('close', () => resolve(output));
+  });
+});
+
+ipcMain.handle('run-strategy', async (evt, { name, input }) => {
+  return new Promise((resolve) => {
+    const args = ['--strategy', name, '-v', `input:${input}`];
+    const proc = spawn('fabric', args);
+    let output = '';
+    proc.stdout.on('data', (d) => {
+      output += d.toString();
+    });
+    proc.on('close', () => resolve(output));
+  });
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fabric-electron",
+  "version": "0.0.1",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "28.1.0"
+  }
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,56 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+function scanVariables(content) {
+  const regex = /\{\{([^{}]+)\}\}/g;
+  const vars = new Set();
+  let match;
+  while ((match = regex.exec(content))) {
+    const name = match[1].trim();
+    if (!name.startsWith('plugin:') && name !== 'input') {
+      vars.add(name);
+    }
+  }
+  return Array.from(vars);
+}
+
+function getPatterns() {
+  const pDir = path.join(__dirname, '..', 'patterns');
+  const names = fs.readdirSync(pDir).filter((p) => fs.statSync(path.join(pDir, p)).isDirectory());
+  return names.map((name) => {
+    const files = ['system.md', 'user.md'];
+    let content = '';
+    for (const f of files) {
+      const fp = path.join(pDir, name, f);
+      if (fs.existsSync(fp)) {
+        content += fs.readFileSync(fp, 'utf8');
+      }
+    }
+    const vars = scanVariables(content);
+    let desc = '';
+    const readme = path.join(pDir, name, 'README.md');
+    if (fs.existsSync(readme)) {
+      const lines = fs.readFileSync(readme, 'utf8').split(/\r?\n/).filter(l => l.trim());
+      if (lines.length) desc = lines[0].replace(/^#\s*/, '');
+    } else if (content) {
+      desc = content.split(/\r?\n/)[0];
+    }
+    return { name, vars, description: desc };
+  });
+}
+
+function getStrategies() {
+  const sDir = path.join(__dirname, '..', 'strategies');
+  return fs.readdirSync(sDir).filter((f) => f.endsWith('.json')).map((file) => {
+    const data = JSON.parse(fs.readFileSync(path.join(sDir, file), 'utf8'));
+    return { name: file.replace('.json', ''), description: data.description || '' };
+  });
+}
+
+contextBridge.exposeInMainWorld('fabricAPI', {
+  patterns: getPatterns(),
+  strategies: getStrategies(),
+  runPattern: (name, vars) => ipcRenderer.invoke('run-pattern', { name, vars }),
+  runStrategy: (name, input) => ipcRenderer.invoke('run-strategy', { name, input })
+});

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -1,0 +1,101 @@
+const patternList = document.getElementById('patternList');
+const strategyList = document.getElementById('strategyList');
+const tabContent = document.getElementById('tabContent');
+const tabs = document.querySelectorAll('.tab');
+const search = document.getElementById('search');
+let history = [];
+
+function switchTab(tab) {
+  tabs.forEach(t => t.classList.remove('active'));
+  document.querySelector(`[data-tab="${tab}"]`).classList.add('active');
+  renderTab(tab);
+}
+
+function renderTab(tab) {
+  if (tab === 'run') {
+    tabContent.innerHTML = '<p>Select a pattern or strategy.</p>';
+  } else if (tab === 'settings') {
+    tabContent.innerHTML = '<h3>Settings</h3><p>Configure API keys and options here.</p>';
+  } else if (tab === 'history') {
+    tabContent.innerHTML = history.map(h => `<pre>${h}</pre>`).join('');
+  }
+}
+
+function filterList() {
+  const q = search.value.toLowerCase();
+  Array.from(patternList.children).forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(q) ? '' : 'none';
+  });
+  Array.from(strategyList.children).forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(q) ? '' : 'none';
+  });
+}
+
+tabs.forEach(t => t.addEventListener('click', () => switchTab(t.dataset.tab)));
+if (search) search.addEventListener('input', filterList);
+renderTab('run');
+
+window.fabricAPI.patterns.forEach(p => {
+  const li = document.createElement('li');
+  li.textContent = p.name;
+  if (p.description) li.title = p.description;
+  li.addEventListener('click', () => openPattern(p));
+  patternList.appendChild(li);
+});
+
+window.fabricAPI.strategies.forEach(s => {
+  const li = document.createElement('li');
+  li.textContent = s.name;
+  if (s.description) li.title = s.description;
+  li.addEventListener('click', () => openStrategy(s));
+  strategyList.appendChild(li);
+});
+
+function openPattern(p) {
+  switchTab('run');
+  let form = '';
+  p.vars.forEach(v => {
+    form += `<label>${v}<input id="var_${v}" /></label>`;
+  });
+  form += '<label>Input<textarea id="var_input"></textarea></label>';
+  form += `<button id="runBtn">Run ${p.name}</button><pre id="output"></pre>`;
+  tabContent.innerHTML = `<h3>${p.name}</h3>${form}`;
+  document.getElementById('runBtn').addEventListener('click', () => runPattern(p));
+}
+
+function runPattern(p) {
+  const vars = {};
+  p.vars.forEach(v => {
+    vars[v] = document.getElementById('var_' + v).value;
+  });
+  vars['input'] = document.getElementById('var_input').value;
+  window.fabricAPI.runPattern(p.name, vars).then(res => {
+    document.getElementById('output').textContent = res;
+    const ts = new Date().toLocaleString();
+    history.push(`[${ts}] PATTERN ${p.name}\n` + JSON.stringify(vars) + '\n' + res);
+    if (document.querySelector('[data-tab="history"]').classList.contains('active')) {
+      renderTab('history');
+    }
+  });
+}
+
+function openStrategy(s) {
+  switchTab('run');
+  const form = '<label>Input<textarea id="str_input"></textarea></label>' +
+    `<button id="runStr">Run ${s.name}</button><pre id="output"></pre>`;
+  const desc = s.description ? `<p>${s.description}</p>` : '';
+  tabContent.innerHTML = `<h3>${s.name}</h3>${desc}${form}`;
+  document.getElementById('runStr').addEventListener('click', () => runStrategy(s));
+}
+
+function runStrategy(s) {
+  const input = document.getElementById('str_input').value;
+  window.fabricAPI.runStrategy(s.name, input).then(res => {
+    document.getElementById('output').textContent = res;
+    const ts = new Date().toLocaleString();
+    history.push(`[${ts}] STRATEGY ${s.name}\nInput: ${input}\n${res}`);
+    if (document.querySelector('[data-tab="history"]').classList.contains('active')) {
+      renderTab('history');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- upgrade electron preload to include descriptions for patterns and strategies and expose `runStrategy`
- allow running strategies and keep timestamps in history
- add search box and strategy support to renderer
- show search UI and run tabs in index.html
- document improved Electron features in README

## Testing
- `go test ./...` *(fails: no route to host)*
- `npm test --silent` in `web` *(fails: vitest not found)*